### PR TITLE
feat: add Official Models section with Anthropic API integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "tailwind-merge": "^2.6.0",
         "tailwindcss": "^4.1.8",
         "zod": "^3.24.1",
+        "zustand": "^5.0.6",
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -1020,6 +1021,8 @@
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "zod": ["zod@3.25.67", "", {}, "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="],
+
+    "zustand": ["zustand@5.0.6", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,6 @@
         "tailwind-merge": "^2.6.0",
         "tailwindcss": "^4.1.8",
         "zod": "^3.24.1",
-        "zustand": "^5.0.6",
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -1021,8 +1020,6 @@
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "zod": ["zod@3.25.67", "", {}, "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="],
-
-    "zustand": ["zustand@5.0.6", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -41,21 +41,7 @@ async fn load_custom_models(app: &AppHandle) -> Result<Vec<CustomModel>, String>
 #[tauri::command]
 pub async fn get_available_models(app: AppHandle) -> Result<ModelConfig, String> {
     let custom_models = load_custom_models(&app).await.unwrap_or_default();
-    let mut env_model = None;
-
-    // Read ANTHROPIC_MODEL environment variable from Claude Settings
-    if let Ok(claude_settings) = crate::commands::claude::get_claude_settings().await {
-        if let Some(env) = claude_settings.data.get("env").and_then(|v| v.as_object()) {
-            if let Some(anthropic_model) = env.get("ANTHROPIC_MODEL").and_then(|v| v.as_str()) {
-                env_model = Some(anthropic_model.to_string());
-            }
-        }
-    }
-
-    // Fallback to system environment variable if not found in Claude Settings
-    if env_model.is_none() {
-        env_model = std::env::var("ANTHROPIC_MODEL").ok();
-    }
+    let env_model = get_env_var("ANTHROPIC_MODEL").await;
 
     Ok(ModelConfig {
         custom_models,
@@ -112,4 +98,94 @@ pub async fn remove_custom_model(app: AppHandle, model_name: String) -> Result<(
 
     // Save
     save_custom_models(app, current_models).await
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicModel {
+    id: String,
+    display_name: Option<String>,
+    created: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicModelsResponse {
+    data: Vec<AnthropicModel>,
+}
+
+/// Helper function to get environment variable from Claude settings or system env
+async fn get_env_var(key: &str) -> Option<String> {
+    // First try to get from Claude settings
+    if let Ok(claude_settings) = crate::commands::claude::get_claude_settings().await {
+        if let Some(env) = claude_settings.data.get("env").and_then(|v| v.as_object()) {
+            if let Some(value) = env.get(key).and_then(|v| v.as_str()) {
+                return Some(value.to_string());
+            }
+        }
+    }
+    
+    // Fallback to system environment variable
+    std::env::var(key).ok()
+}
+
+/// Fetch official models from Anthropic API
+async fn fetch_official_models_from_api() -> Result<Vec<CustomModel>, String> {
+    let api_key = get_env_var("ANTHROPIC_API_KEY").await
+        .ok_or("Anthropic API key not found. Please set ANTHROPIC_API_KEY in environment variables or Claude settings.")?;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get("https://api.anthropic.com/v1/models")
+        .header("x-api-key", &api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("User-Agent", "Claudia-App")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch models from Anthropic API: {}", e))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(format!("Anthropic API request failed with status {}: {}", status, error_text));
+    }
+
+    let api_response: AnthropicModelsResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Anthropic API response: {}", e))?;
+
+    let mut models: Vec<CustomModel> = api_response.data
+        .into_iter()
+        .map(|model| {
+            let description = model.created
+                .map(|created| format!("Official Anthropic model (created: {})", created))
+                .unwrap_or_else(|| "Official Anthropic model".to_string());
+
+            CustomModel {
+                name: model.display_name.unwrap_or(model.id.clone()),
+                identifier: model.id,
+                description: Some(description),
+            }
+        })
+        .collect();
+
+    // Sort models by identifier for consistent ordering
+    models.sort_by(|a, b| a.identifier.cmp(&b.identifier));
+
+    Ok(models)
+}
+
+#[tauri::command]
+pub async fn get_official_models() -> Result<Vec<CustomModel>, String> {
+    // Try to fetch from Anthropic API
+    match fetch_official_models_from_api().await {
+        Ok(models) => {
+            log::info!("Successfully fetched {} models from Anthropic API", models.len());
+            Ok(models)
+        }
+        Err(e) => {
+            log::warn!("Failed to fetch from Anthropic API: {}", e);
+            // Return empty list if API call fails
+            Ok(Vec::new())
+        }
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -43,7 +43,7 @@ use commands::storage::{
     storage_insert_row, storage_execute_sql, storage_reset_database,
 };
 use commands::models::{
-    get_available_models, save_custom_models, add_custom_model, remove_custom_model,
+    get_available_models, save_custom_models, add_custom_model, remove_custom_model, get_official_models,
 };
 use process::ProcessRegistryState;
 use std::sync::Mutex;
@@ -204,6 +204,7 @@ fn main() {
             save_custom_models,
             add_custom_model,
             remove_custom_model,
+            get_official_models,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1895,5 +1895,17 @@ export const api = {
       console.error("Failed to remove custom model:", error);
       throw error;
     }
+  },
+
+  /**
+   * Get official Anthropic models from API
+   */
+  async getOfficialModels(): Promise<CustomModel[]> {
+    try {
+      return await invoke<CustomModel[]>("get_official_models");
+    } catch (error) {
+      console.error("Failed to get official models:", error);
+      throw error;
+    }
   }
 };


### PR DESCRIPTION
- Add Official Models UI section in Settings → Models tab with collapsible functionality
- Implement Anthropic Models List API integration in Rust backend
- Add get_official_models Tauri command with proper error handling
- Create unified environment variable access function (get_env_var)
- Add frontend API call for fetching official models
- Include model selection and add-to-custom functionality
- Maintain visual consistency with existing Custom Models section
- Return empty list on API failure instead of hardcoded fallbacks
- Optimize code by removing unused structures and duplicate logic

🤖 Generated with [Claude Code](https://claude.ai/code)